### PR TITLE
PINGREQの送信タイミングを拡張

### DIFF
--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttAsyncClient.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/MqttAsyncClient.java
@@ -779,6 +779,9 @@ public class MqttAsyncClient implements MqttClientInterface, IMqttAsyncClient {
 
 		this.mqttConnection.setIncomingTopicAliasMax(this.connOpts.getTopicAliasMaximum());
 
+		//
+		this.mqttConnection.setEnableExPingReq(connOpts.isEnableExPingReq());
+
 		comms.setNetworkModuleIndex(0);
 		connectActionListener.connect();
 

--- a/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientState.java
+++ b/org.eclipse.paho.mqttv5.client/src/main/java/org/eclipse/paho/mqttv5/client/internal/ClientState.java
@@ -753,45 +753,63 @@ public class ClientState implements MqttState {
 					throw ExceptionHelper.createMqttException(MqttClientException.REASON_CODE_WRITE_TIMEOUT);
 				}
 
-				// 1. Is a ping required by the client to verify whether the broker is down?
-				// Condition: ((pingOutstanding == 0 && (time - lastInboundActivity >= keepAlive
-				// + delta)))
-				// In this case only one ping is sent. If not confirmed, client will assume a
-				// lost connection to the broker.
-				// 2. Is a ping required by the broker to keep the client alive?
-				// Condition: (time - lastOutboundActivity >= keepAlive - delta)
-				// In this case more than one ping outstanding may be necessary.
-				// This would be the case when receiving a large message;
-				// the broker needs to keep receiving a regular ping even if the ping response
-				// are queued after the long message
-				// If lacking to do so, the broker will consider my connection lost and cut my
-				// socket.
-				if ((pingOutstanding == 0 && (time - lastInboundActivity >= keepAlive - delta))
-						|| (time - lastOutboundActivity >= keepAlive - delta)) {
+				// If extended ping is enabled, ping is sent for each keepAlive.
+				if (mqttConnection.isEnableExPingReq()) {
+					if (time - lastPing >= keepAlive - delta){
 
-					// @TRACE 620=ping needed. keepAlive={0} lastOutboundActivity={1}
-					// lastInboundActivity={2}
-					log.fine(CLASS_NAME, methodName, "620", new Object[] { Long.valueOf(keepAlive),
-							Long.valueOf(lastOutboundActivity), Long.valueOf(lastInboundActivity) });
+						token = new MqttToken(clientComms.getClient().getClientId());
+						if (pingCallback != null) {
+							token.setActionCallback(pingCallback);
+						}
+						tokenStore.saveToken(token, pingCommand);
+						pendingFlows.insertElementAt(pingCommand, 0);
 
-					// pingOutstanding++; // it will be set after the ping has been written on the
-					// wire
-					// lastPing = time; // it will be set after the ping has been written on the
-					// wire
-					token = new MqttToken(clientComms.getClient().getClientId());
-					if (pingCallback != null) {
-						token.setActionCallback(pingCallback);
+						nextPingTime = keepAlive;
+						notifyQueueLock();
+					} else {
+						nextPingTime = Math.max(1, keepAlive - (time - lastPing));
 					}
-					tokenStore.saveToken(token, pingCommand);
-					pendingFlows.insertElementAt(pingCommand, 0);
-
-					nextPingTime = keepAlive;
-
-					// Wake sender thread since it may be in wait state (in ClientState.get())
-					notifyQueueLock();
 				} else {
-					log.fine(CLASS_NAME, methodName, "634", null);
-					nextPingTime = Math.max(1, keepAlive - (time - lastOutboundActivity));
+					// 1. Is a ping required by the client to verify whether the broker is down?
+					// Condition: ((pingOutstanding == 0 && (time - lastInboundActivity >= keepAlive
+					// + delta)))
+					// In this case only one ping is sent. If not confirmed, client will assume a
+					// lost connection to the broker.
+					// 2. Is a ping required by the broker to keep the client alive?
+					// Condition: (time - lastOutboundActivity >= keepAlive - delta)
+					// In this case more than one ping outstanding may be necessary.
+					// This would be the case when receiving a large message;
+					// the broker needs to keep receiving a regular ping even if the ping response
+					// are queued after the long message
+					// If lacking to do so, the broker will consider my connection lost and cut my
+					// socket.
+					if ((pingOutstanding == 0 && (time - lastInboundActivity >= keepAlive - delta))
+							|| (time - lastOutboundActivity >= keepAlive - delta)) {
+
+						// @TRACE 620=ping needed. keepAlive={0} lastOutboundActivity={1}
+						// lastInboundActivity={2}
+						log.fine(CLASS_NAME, methodName, "620", new Object[] { Long.valueOf(keepAlive),
+								Long.valueOf(lastOutboundActivity), Long.valueOf(lastInboundActivity) });
+
+						// pingOutstanding++; // it will be set after the ping has been written on the
+						// wire
+						// lastPing = time; // it will be set after the ping has been written on the
+						// wire
+						token = new MqttToken(clientComms.getClient().getClientId());
+						if (pingCallback != null) {
+							token.setActionCallback(pingCallback);
+						}
+						tokenStore.saveToken(token, pingCommand);
+						pendingFlows.insertElementAt(pingCommand, 0);
+
+						nextPingTime = keepAlive;
+
+						// Wake sender thread since it may be in wait state (in ClientState.get())
+						notifyQueueLock();
+					} else {
+						log.fine(CLASS_NAME, methodName, "634", null);
+						nextPingTime = Math.max(1, keepAlive - (time - lastOutboundActivity));
+					}
 				}
 			}
 			// @TRACE 624=Schedule next ping at {0}

--- a/org.eclipse.paho.sample.mqttv5app/src/main/java/org/eclipse/paho/sample/mqttv5app/Publisher.java
+++ b/org.eclipse.paho.sample.mqttv5app/src/main/java/org/eclipse/paho/sample/mqttv5app/Publisher.java
@@ -1,0 +1,54 @@
+package org.eclipse.paho.sample.mqttv5app;
+
+import org.eclipse.paho.mqttv5.client.IMqttToken;
+import org.eclipse.paho.mqttv5.client.MqttAsyncClient;
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Publisher {
+    public static void main(String[] args) {
+
+        String url = "tcp://localhost:1883";
+        String clientId = "publisher";
+        MemoryPersistence persistence = new MemoryPersistence();
+
+        MqttConnectionOptions conOpts = new MqttConnectionOptions();
+        conOpts.setEnableExPingReq(true);
+        conOpts.setKeepAliveInterval(2);
+
+
+        MqttAsyncClient client = null;
+        try {
+            client = new MqttAsyncClient(url, clientId, persistence);
+            IMqttToken mt =  client.connect(conOpts);
+            mt.waitForCompletion();
+            System.out.println("Connected");
+
+            Thread.sleep(1000);
+            for (int i = 0; i < 10; i++) {
+                MqttMessage ms = new MqttMessage("Hello World".getBytes());
+                ms.setQos(1);
+                client.publish("t", ms);
+                Thread.sleep(1000);
+            }
+
+            System.out.println("Wait: please enter");
+            BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+            br.readLine();
+
+            System.out.println("Disconnected");
+            client.disconnect();
+        } catch (MqttException e) {
+            System.out.println("reason "+e.getReasonCode());
+            System.out.println("msg "+e.getMessage());
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/org.eclipse.paho.sample.mqttv5app/src/main/java/org/eclipse/paho/sample/mqttv5app/Sample.java
+++ b/org.eclipse.paho.sample.mqttv5app/src/main/java/org/eclipse/paho/sample/mqttv5app/Sample.java
@@ -1,5 +1,7 @@
 package org.eclipse.paho.sample.mqttv5app;
 
+
+
 public class Sample {
     public static void main(String[] args) {
         System.out.println("Hello World!");

--- a/org.eclipse.paho.sample.mqttv5app/src/main/java/org/eclipse/paho/sample/mqttv5app/Subscriber.java
+++ b/org.eclipse.paho.sample.mqttv5app/src/main/java/org/eclipse/paho/sample/mqttv5app/Subscriber.java
@@ -1,0 +1,81 @@
+package org.eclipse.paho.sample.mqttv5app;
+
+import org.eclipse.paho.mqttv5.client.*;
+import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Subscriber implements MqttCallback {
+    public static void main(String[] args) {
+
+        String url = "tcp://localhost:1883";
+        String clientId = "subscriber";
+        MemoryPersistence persistence = new MemoryPersistence();
+
+        MqttConnectionOptions conOpts = new MqttConnectionOptions();
+        conOpts.setEnableExPingReq(true);
+        conOpts.setKeepAliveInterval(2);
+
+
+        MqttAsyncClient client = null;
+        try {
+            client = new MqttAsyncClient(url, clientId, persistence);
+            Subscriber sub = new Subscriber();
+            client.setCallback(sub);
+
+            IMqttToken mt =  client.connect(conOpts);
+            mt.waitForCompletion();
+            System.out.println("Connected");
+
+            client.subscribe("t", 1);
+            System.out.println("Subscribe");
+
+            System.out.println("Wait: please enter");
+            BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+            br.readLine();
+
+            System.out.println("Disconnected");
+            client.disconnect();
+        } catch (MqttException e) {
+            System.out.println("reason "+e.getReasonCode());
+            System.out.println("msg "+e.getMessage());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void disconnected(MqttDisconnectResponse disconnectResponse) {
+        System.out.println("Disconnected");
+    }
+
+    @Override
+    public void mqttErrorOccurred(MqttException exception) {
+        System.out.println("Error Occurred");
+    }
+
+    @Override
+    public void messageArrived(String topic, MqttMessage message) throws Exception {
+        System.out.println("Message Arrived");
+    }
+
+    @Override
+    public void deliveryComplete(IMqttToken token) {
+        System.out.println("Delivery Complete");
+    }
+
+    @Override
+    public void connectComplete(boolean reconnect, String serverURI) {
+        System.out.println("Connection Complete");
+    }
+
+    @Override
+    public void authPacketArrived(int reasonCode, MqttProperties properties) {
+        System.out.println("Auth Packet Arrived");
+    }
+}


### PR DESCRIPTION
- 拡張PINGREQを利用するフラグを`MqttConnectState`に反映
- フラグが有効な場合、PINGREQの送信条件を前回のping送信時刻との比較のみにする